### PR TITLE
Add resourcedictionary ckan patch

### DIFF
--- a/ckan/patches/ckan/02_resourcedictionary_templates.patch
+++ b/ckan/patches/ckan/02_resourcedictionary_templates.patch
@@ -1,0 +1,60 @@
+diff --git a/ckan/templates/package/resource_read.html b/ckan/templates/package/resource_read.html
+index 7c8c6f9..6f2342a 100644
+--- a/ckan/templates/package/resource_read.html
++++ b/ckan/templates/package/resource_read.html
+@@ -40,12 +40,14 @@
+                     <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+                   {% elif not res.has_views and not res.url_type == 'upload' %}
+                     <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
++                  {% elif res.has_views and not res.url_type == 'upload' %}
++                    <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+                   {% else %}
+                     <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+                   {% endif %}
+                 </a>
+                 {% block download_resource_button %}
+-                  {% if res.datastore_active %}
++                  {% if res.datastore_active and res.url_type == 'datastore' %}
+                 <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                     <span class="caret"></span>
+                   </button>
+@@ -224,4 +226,4 @@
+   {% block resource_license %}
+     {% snippet "snippets/social.html" %}
+   {% endblock %}
+-{% endblock %}
++{% endblock %}
+\ No newline at end of file
+diff --git a/ckanext/datastore/templates-bs2/package/resource_read.html b/ckanext/datastore/templates-bs2/package/resource_read.html
+index 3c77876..1d856e0 100644
+--- a/ckanext/datastore/templates-bs2/package/resource_read.html
++++ b/ckanext/datastore/templates-bs2/package/resource_read.html
+@@ -2,7 +2,7 @@
+ 
+ {% block resource_actions_inner %}
+   {{ super() }}
+-  {% if res.datastore_active %}
++  {% if res.datastore_active and res.url_type == 'datastore' %}
+     <li>{% snippet 'package/snippets/data_api_button.html', resource=res %}</li>
+   {% endif %}
+ {% endblock %}
+@@ -34,4 +34,4 @@
+     </div>
+   {% endif %}
+   {{ super() }}
+-{% endblock %}
++{% endblock %}
+\ No newline at end of file
+diff --git a/ckanext/datastore/templates/package/resource_read.html b/ckanext/datastore/templates/package/resource_read.html
+index 2e1fdef..9caad53 100644
+--- a/ckanext/datastore/templates/package/resource_read.html
++++ b/ckanext/datastore/templates/package/resource_read.html
+@@ -2,7 +2,7 @@
+ 
+ {% block resource_actions_inner %}
+   {{ super() }}
+-  {% if res.datastore_active %}
++  {% if res.datastore_active and res.url_type == 'datastore' %}
+     <li>{% snippet 'package/snippets/data_api_button.html', resource=res %}</li>
+   {% endif %}
+ {% endblock %}


### PR DESCRIPTION
Avoids UI errors when using data dictionaries for datasets that are not stored in the datastore.