### PR TITLE
Create a quick deploy docker compose file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ TEST_CKAN_DATASTORE_WRITE_URL=postgresql://ckan:ckan@db/datastore_test
 TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_test
 
 # CKAN core
+## If use docker-compose.ghcr.yml only "*.*.*" versions available in: https://github.com/mjanez/ckan-docker/pkgs/container/ckan-spatial
 CKAN_VERSION=2.9.8
 CKAN_SITE_ID=default
 # CKAN_SITE_URL = http:/ or https:/ + APACHE_SERVER_NAME. Optionally the APACHE_HOST_PORT if different from 80 

--- a/README.md
+++ b/README.md
@@ -198,30 +198,22 @@ Use this if you are a maintainer and will not be making code changes to CKAN or 
     ```bash
     docker compose build 
     ```
+
     >**Note**<br>
-    > NGINX CKAN without ckan-pycsw and Apache:
-    >```bash
-    >docker compose -f docker-compose.nginx.yml build
-    >```
-  
+    > You can use a [deploy in 5 minutes](#quick-mode) if you just want to test the package. 
 
 4. Start the containers:
     ```bash
     docker compose up
     ```
 
-    >**Note**<br>
-    > NGINX CKAN without ckan-pycsw and Apache:
-    >```bash
-    >docker compose -f docker-compose.nginx.yml up
-    >```
-
 This will start up the containers in the current window. By default the containers will log direct to this window with each container
 using a different colour. You could also use the -d "detach mode" option ie: `docker compose up -d` if you wished to use the current 
 window for something else.
 
 >**Note**<br>
-> Or `docker compose up --build` to build & up the containers.
+> * Or `docker compose up --build` to build & up the containers.
+> * Or `docker compose -f docker-compose.nginx.yml up -d --build` to use the NGINX version.
 
 At the end of the container start sequence there should be 6 containers running (or 5 if use NGINX Docker Compose file)
 
@@ -234,7 +226,7 @@ After this step, CKAN should be running at {`APACHE_SERVER_NAME`}{`APACHE_CKAN_L
 |1b8d9789c29a|redis:7-alpine                           |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|6379/tcp              |redis                |       |
 |7f162741254d|ckan/ckan-solr:2.9-solr8-spatial  |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|8983/tcp              |solr                 |       |
 |2cdd25cea0de|ckan-docker-db                    |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|5432/tcp              |db                   |       |
-|9cdj25dae6gr|ckan-docker-pycsw                    |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|8000/tcp              |db                   |       |
+|9cdj25dae6gr|ckan-docker-pycsw                    |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|8000/tcp              |pycsw                   |       |
 
 
 #### Configure a docker compose service to start on boot
@@ -292,6 +284,17 @@ To have Docker Compose run automatically when you reboot a machine, you can foll
   # Check the status
   sudo systemctl status ckan-docker-compose
   ```
+
+### Quick mode
+If you just want to test the package and see the general functionality of the platform, you can use the `ckan-spatial` image from the [Github container registry](https://github.com/mjanez/ckan-docker/pkgs/container/ckan-spatial):
+    
+  ```bash
+  cp .env.example .env
+  # Edit the envvars in the .env as you like and start the containers.
+  docker compose -f docker-compose.ghcr.yml up -d --build 
+  ```
+
+It will download the pre-built image and deploy all the containers. Remember to use your own domain by changing `localhost` in the `.env` file.
 
 ### Development mode
 Use this mode if you are making code changes to CKAN and either creating new extensions or making code changes to existing extensions. This mode also uses the `.env` file for config options.

--- a/ckan/Dockerfile.ghcr
+++ b/ckan/Dockerfile.ghcr
@@ -1,0 +1,37 @@
+FROM ghcr.io/mjanez/ckan-spatial:ckan-2.9.8
+
+# Set up environment variables
+ENV APP_DIR=/srv/app
+ENV TZ=UTC
+RUN echo ${TZ} > /etc/timezone
+
+# Make sure both files are not exactly the same
+RUN if ! [ /usr/share/zoneinfo/${TZ} -ef /etc/localtime ]; then \
+    cp /usr/share/zoneinfo/${TZ} /etc/localtime ;\
+    fi ;
+
+# Used to configure the container environment by setting environment variables, creating users, running initialization scripts, .etc
+COPY docker-entrypoint.d/* /docker-entrypoint.d/
+
+# Update who.ini with APACHE_CKAN_LOCATION
+COPY setup/who.ini ${APP_DIR}/
+
+# Apply any patches needed to CKAN core
+COPY patches ${APP_DIR}/patches
+
+#  Updated version of the Dockerfile RUN command that skips applying a patch if a reversed or previously applied patch is detected
+RUN for d in $APP_DIR/patches/*; do \
+    if [ -d $d ]; then \
+        for f in `ls $d/*.patch | sort -g`; do \
+            cd $SRC_DIR/`basename "$d"` && \
+            if patch -R --dry-run -p1 < "$f"; then \
+                echo "$0: Patch $f has already been applied or reversed, skipping..."; \
+            else \
+                echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; \
+                patch -p1 < "$f" ; \
+            fi \
+        done ; \
+    fi ; \
+done
+
+CMD $APP_DIR/start_ckan.sh

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,4 +1,3 @@
-# With NGINX and without ckan-pycsw
 version: "3"
 
 volumes:
@@ -7,11 +6,11 @@ volumes:
   solr_data:
 
 services:
-
-  nginx:
-    container_name: ${NGINX_CONTAINER_NAME}
+   
+  apache:
+    container_name: ${APACHE_CONTAINER_NAME}
     build:
-      context: nginx/
+      context: apache/
       dockerfile: Dockerfile
     env_file:
       - .env
@@ -24,14 +23,12 @@ services:
       ckan:
         condition: service_healthy
     ports:
-      - "0.0.0.0:${NGINX_PORT_HOST}:${NGINX_PORT}"
-      - "0.0.0.0:${NGINX_SSLPORT_HOST}:${NGINX_SSLPORT}"
-    
+      - "0.0.0.0:${APACHE_PORT_HOST}:${APACHE_PORT}"
+    restart: on-failure:3
+
   ckan:
     container_name: ${CKAN_CONTAINER_NAME}
-    build:
-      context: ckan/
-      dockerfile: Dockerfile
+    image: ghcr.io/mjanez/ckan-spatial:ckan-${CKAN_VERSION}
     env_file:
       - .env
     logging:
@@ -52,8 +49,32 @@ services:
       - ckan_storage:/var/lib/ckan
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
-    
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:${CKAN_PORT}"]
+
+  pycsw:
+    container_name: ${PYCSW_CONTAINER_NAME}
+    build:
+      context: ckan-pycsw/
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    logging:
+      driver: "json-file"
+      options:
+          max-size: "100m"
+          max-file: "10"
+    depends_on:
+      ckan:
+        condition: service_healthy
+    ports:
+      - "0.0.0.0:${PYCSW_PORT_HOST}:${PYCSW_PORT}"
+    volumes:
+        - ./log:${APP_DIR}/log
+        - ./metadata:${APP_DIR}/metadata
+    restart: on-failure:3
+    healthcheck:
+      test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:${PYCSW_PORT}"]
+
   db:
     container_name: ${POSTGRESQL_CONTAINER_NAME}
     build:
@@ -65,13 +86,13 @@ services:
       - DATASTORE_READONLY_PASSWORD=${DATASTORE_READONLY_PASSWORD}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - PGDATA=/var/lib/postgresql/data/db
+    volumes:
+      - pg_data:/var/lib/postgresql/data
     logging:
       driver: "json-file"
       options:
           max-size: "100m"
           max-file: "10"
-    volumes:
-      - pg_data:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "ckan"]

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -28,7 +28,9 @@ services:
 
   ckan:
     container_name: ${CKAN_CONTAINER_NAME}
-    image: ghcr.io/mjanez/ckan-spatial:ckan-${CKAN_VERSION}
+    build:
+      context: ckan/
+      dockerfile: Dockerfile.ghcr
     env_file:
       - .env
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
     build:
       context: ckan/
       dockerfile: Dockerfile
-    image: ghcr.io/mjanez/ckan-spatial:ckan-2.9.8
     env_file:
       - .env
     logging:


### PR DESCRIPTION
- Remove ckan-spatial from default docker compose file
- Create a docker-compose.ghcr.yml to use the ckan-spatial image from container registry
- Update the README to include this information
- Update .env.example to info about CKAN_VERSION ennvar