### PR TITLE
Add ckanext-fluent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,9 +121,10 @@ CKAN__VIEWS__DEFAULT_VIEWS="image_view webpage_view text_view recline_view wmts_
 # Localization
 CKAN__LOCALE_DEFAULT="en"
 CKAN__LOCALE_ORDER="en es pt_BR ja it cs_CZ ca fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv"
+CKAN__LOCALES_OFFERED="en es pt_BR ja it cs_CZ ca fr el sv sr sr@latin no sk fi ru de pl nl bg ko_KR hu sa sl lv"
 
 # Extensions
-CKAN__PLUGINS="envvars stats text_view image_view webpage_view recline_view resourcedictionary datastore xloader harvest ckan_harvester spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester resource_proxy geo_view geojson_view wmts_view shp_view dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface scheming_dcat_datasets scheming_dcat_groups scheming_dcat_organizations scheming_dcat pdf_view pages"
+CKAN__PLUGINS="envvars stats text_view image_view webpage_view recline_view resourcedictionary datastore xloader harvest ckan_harvester spatial_metadata spatial_query spatial_harvest_metadata_api csw_harvester waf_harvester doc_harvester resource_proxy geo_view geojson_view wmts_view shp_view dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface scheming_dcat_datasets scheming_dcat_groups scheming_dcat_organizations scheming_dcat pdf_view pages fluent"
 
 # ckanext-harvest
 CKAN__HARVEST__MQ__TYPE=redis
@@ -162,7 +163,7 @@ CKANEXT__SCHEMING_DCAT_GEOMETADATA_BASE_URI=${PYCSW_URL}
 CKANEXT__SCHEMING_DCAT_DATASET_SCHEMA="ckanext.scheming_dcat:schemas/geodcatap/geodcatap_dataset.yaml"
 CKANEXT__SCHEMING_DCAT_GROUP_SCHEMAS="ckanext.scheming_dcat:schemas/geodcatap/geodcatap_group.json"
 CKANEXT__SCHEMING_DCAT_ORGANIZATION_SCHEMAS="ckanext.scheming_dcat:schemas/geodcatap/geodcatap_org.json"
-CKANEXT__SCHEMING_DCAT_PRESETS="ckanext.scheming_dcat:schemas/geodcatap/geodcatap_presets.json"
+CKANEXT__SCHEMING_DCAT_PRESETS="ckanext.scheming_dcat:schemas/default_presets.json ckanext.fluent:presets.json"
 ## Facets: setup_scheming.sh
 CKANEXT__SCHEMING_DCAT_FACET_LIST="theme groups theme_eu dcat_type groups publisher_name publisher_type spatial_uri owner_org res_format frequency tags tag_uri conforms_to"
 CKANEXT__SCHEMING_DCAT_ORGANIZATION_CUSTOM_FACETS=True
@@ -173,8 +174,8 @@ CKANEXT__PAGES__ALOW_HTML=False
 CKANEXT__PAGES__ORGANIZATION=True
 CKANEXT__PAGES__GROUP=True
 CKANEXT__PAGES__ABOUT_MENU=False
-CKANEXT__PAGES__GROUP_MENU=False
-CKANEXT__PAGES__ORGANIZATION_MENU=False
+CKANEXT__PAGES__GROUP_MENU=True
+CKANEXT__PAGES__ORGANIZATION_MENU=True
 
 # WIP: ckanext-sparql_interface
 CKANEXT__SPARQL__ENDPOINT_URL=https://dbpedia.org/sparql

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -21,6 +21,7 @@ COPY req_fixes req_fixes
 ### Resource dictionary - v1.0.1 ###
 ### Pages - v0.5.2 ###
 ### PDFView - 0.0.8 ###
+### Fluent - v1.0.1  (Forked stable version) ###
 ### Scheming DCAT - v2.0.0 (GeoDCAT-AP/NTI-RISP extended version) ###
 ### SPARQL Interface - 2.0.1 ###
 RUN echo ${TZ} > /etc/timezone && \
@@ -49,6 +50,8 @@ RUN echo ${TZ} > /etc/timezone && \
     pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-pages.git@v0.5.2#egg=ckanext-pages && \
     echo "ckan/ckanext-pdfview" && \
     pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-pdfview.git@0.0.8#egg=ckanext-pdfview && \
+    echo "mjanez/ckanext-fluent" && \
+    pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-fluent.git@v1.0.1#egg=ckanext-fluent && \
     echo "mjanez/ckanext-scheming_dcat" && \
     pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-scheming_dcat.git@v2.0.0#egg=ckanext_scheming_dcat && \
     pip3 install --no-cache-dir -r https://raw.githubusercontent.com/mjanez/ckanext-scheming_dcat/v2.0.0/requirements.txt


### PR DESCRIPTION
- Add ckanext-fluent to Dockerfile to allow multilang fields in schemas.
- Add config for langs offered in CKAN.