### PR TITLE
Update GitHub Actions workflow to set VERSION to 'master' when the github.head_ref is 'master'.

### DIFF
--- a/.github/workflows/docker-manual.yml
+++ b/.github/workflows/docker-manual.yml
@@ -35,7 +35,12 @@ jobs:
 
       - name: Extract tag version from branch name
         id: extract_tag_version
-        run: echo "VERSION=$(echo ${{ github.head_ref }} | sed 's/^ckan-//')" >> $GITHUB_ENV
+        run: |
+          if [ "${{ github.head_ref }}" = "master" ]; then
+            echo "VERSION=master" >> $GITHUB_ENV
+          else
+            echo "VERSION=$(echo ${{ github.head_ref }} | sed 's/^ckan-//')" >> $GITHUB_ENV
+          fi
 
       - name: Extract Docker metadata
         id: meta


### PR DESCRIPTION


This prevents attempting to extract a version from the branch name when on the master branch, ensuring the Docker image is tagged correctly.