### PR TITLE
Update ckanext-schemingdcat to 4.5.0 in Dockerfile

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -23,7 +23,7 @@ COPY req_fixes req_fixes
 ## PDFView - 0.0.8 ##
 ## Fluent - v1.0.1  (mjanez/Forked stable version) ##
 ## OpenAPI - v1.0.0 (mjanez stable version) ##
-## Scheming DCAT - v4.4.1 (mjanez/GeoDCAT-AP/NTI-RISP extended version) ##
+## Scheming DCAT - v4.5.0 (mjanez/GeoDCAT-AP/NTI-RISP extended version) ##
 RUN echo ${TZ} > /etc/timezone && \
     if ! [ /usr/share/zoneinfo/${TZ} -ef /etc/localtime ]; then cp /usr/share/zoneinfo/${TZ} /etc/localtime; fi && \
     # Install patch utility
@@ -60,7 +60,7 @@ RUN echo ${TZ} > /etc/timezone && \
     echo "mjanez/ckanext-openapi" && \
     pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-openapi.git@v1.0.0#egg=ckanext-openapi && \
     echo "mjanez/ckanext-schemingdcat" && \
-    pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-schemingdcat.git@v4.4.1#egg=ckanext_schemingdcat && \
+    pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-schemingdcat.git@v4.5.0#egg=ckanext_schemingdcat && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-schemingdcat/requirements.txt && \
     # Remove system cache
     apt-get clean && \


### PR DESCRIPTION
This pull request includes updates to the version of the `ckanext-schemingdcat` extension in the `ckan/Dockerfile`. The most important changes are:

Version updates:
* Updated `Scheming DCAT` from version `v4.4.1` to `v4.5.0` in the comments section of the `ckan/Dockerfile`.
* Updated the `pip3 install` command to install `ckanext-schemingdcat` version `v4.5.0` instead of `v4.4.1` in the `ckan/Dockerfile`.